### PR TITLE
Fix errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # cSweeper
 
-cSweeper is a recreation of Minesweeper written in C for the Bash terminal.
+cSweeper is a program that is based on Minesweeper game and is written in C for the Bash terminal.
 
 
 ### Installation
 1. Clone the git repository to your local machine
-2. Run `make` in the command-line to create the game file
-3. Run cSweeper by typing `./cSweeper` into the command-line
+2. Run `make` in the command line to create the game file
+3. Execute cSweeper by typing `./cSweeper` into the command line
 
 ### Gameplay
 
 The objective of the game is to clear the rectangular board without clicking any mines
 
-Commands are inputed by typing `x y` into the command-line which represents the (row, column) coordinates of the cell you want to reveal
+Commands are inputed by typing `x y` into the command line which represents the (row, column) coordinates of the cell you want to reveal
 


### PR DESCRIPTION
"Recreation" --> ambiguous use of the word. Assimilated to amusement or distraction
Correction: cSweeper is a program that is based on Minesweeper game and is written in C for the Bash terminal.
"Run cSweeper" --> ambiguous. “Execute cSweeper” is more adequate
"Command-line" --> command line. We use the hyphen if the word is describing another one. 
Example: command-line interface

Fixes #4 
